### PR TITLE
Profile-tables Look and Functionality Improved

### DIFF
--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -4,8 +4,7 @@
 
 <img src="/static/img/favicon.png" style="float: left; max-width: 48px; margin-right: 20px;" alt="">
 
-<h1><span class="font-semi-bold">Steel Profiles REST API</span>
-</h1>
+<h1 class="font-semi-bold">Steel Profiles REST API</h1>
 
 <div style="clear:both;"></div>
 <br>

--- a/templates/home/profiletable.html
+++ b/templates/home/profiletable.html
@@ -4,13 +4,30 @@
 
 <img src="/static/img/favicon.png" style="float: left; max-width: 48px; margin-right: 20px;" alt="">
 
-<h1><span class="font-semi-bold">{{ profile_type }}</span>
-</h1>
+<h1 class="font-semi-bold">{{ profile_type }}</h1>
 
-<div class="profile-table">
+<div class="profile-table table-responsive">
     {{ df_html | safe }}
 </div>
 
-</div>
-
+<script type="text/javascript">
+    window.onload = () => {
+        let rows = document.getElementById("profile-table").rows
+        for(let i=1; i<rows.length; ++i) {
+            for(let j=0; j<rows[i].cells.length; ++j) {
+                rows[i].cells[j].onclick = function() {
+                    navigator.clipboard.writeText(this.innerHTML)
+                }
+                rows[i].cells[j].style.cursor = "pointer";
+                rows[i].cells[j].setAttribute("data-bs-toggle", "tooltip")
+                rows[i].cells[j].setAttribute("data-bs-placement", "bottom")
+                rows[i].cells[j].setAttribute("title", "Click to Copy")
+            }
+        }
+        let tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+        let tooltipList = tooltipTriggerList.map(function (tooltipTrigger) {
+            return new bootstrap.Tooltip(tooltipTrigger)
+        })
+    }
+</script>
 {% endblock %}

--- a/templates/shared/layout.html
+++ b/templates/shared/layout.html
@@ -11,7 +11,7 @@
 
     <title>Steel Profiles API</title>
     <link rel="shortcut icon" type="image/png" href="static/img/favicon.png" />
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU" crossorigin="anonymous">
     <link href="/static/css/docs.css" rel="stylesheet">
     <link href="/static/css/styles.css" rel="stylesheet">
 
@@ -27,19 +27,9 @@
 <body>
     <div class="starter-template">
         <div class="container">
-            <div class="row">
-                <div class="col-md-2">
-                </div>
-                <div class="col-md-10">
-                    <div>
-
-                        {% block content %}
-                        <div class="content">
-                        </div>
-                        {% endblock %}
-
-                    </div>
-                </div>
+            <div class="content">
+                {% block content %}
+                {% endblock %}
             </div>
         </div>
     </div>

--- a/views/tables.py
+++ b/views/tables.py
@@ -23,7 +23,7 @@ def _create_profile_table_endpoint(profile_type: str):
     def uppercase_profile_endpoint_template(request: Request):
 
         df = pd.read_csv(f"./assets/{profile_type}.csv")
-        df_html = df.to_html()
+        df_html = df.to_html(classes="table table-hover fs-5", justify="start", table_id="profile-table")
 
         return templates.TemplateResponse(
             "home/profiletable.html",


### PR DESCRIPTION
- Bumped Bootstrap to v5
- Improved looks of Profile-table page
- Profile-table is now **responsive**
- Added **row-hover** effect for Profile-table
- Profile-table cells can be **clicked** to **Copy** content (Also added a tooltip on hover)
- Made slight changes to `index.html` and `profiletable.html` heading (`<h1>` tag) to adapt to Bootstrap v5 sizes
- Minor changes to `layout.html` to bring pages content to center (was shifted slightly to right, previously)

Addresses Issue #8

Screenshot for your reference (Including the hover tooltip)
![steelprofiles](https://user-images.githubusercontent.com/31766648/135621746-67de8a22-c4ff-45ec-bda9-b3366eb5e989.png)