### PR TITLE
Improve mobile layout

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -31,10 +31,10 @@ body {
 
 .toggleDarkMode {
     width: 50px; 
+    height: 47px; 
     border: 0px; 
     padding: 0px;
-    margin-left: 24px;
-    border-radius: 24px;
+    border-radius: 50%;
     background-color: #000000;
 }
 
@@ -44,8 +44,8 @@ body {
 
 #modeIcon {
     border: 0px;
-    border-radius: 24px;
-    padding: 2px;
+    border-radius: 50%;
+    padding: 1px 2px;
     width: 50px;
 
 }
@@ -74,6 +74,44 @@ p {
 .font-bold {
     font-weight: 700;
 }
+
+.site-header {
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: center;
+    align-items: center;
+}
+
+.site-icon {
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin: 16px 8px 8px 8px;
+}
+
+.site-title {
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: auto;
+    padding-right: 60px;
+}
+
+.site-social-icons {
+    flex-shrink: 1;
+    display: flex;
+    flex-wrap: wrap-reverse;
+    justify-content: flex-end;
+    padding: 10px 6px;
+    width: fit-content;
+    position: absolute;
+    right: 0px;
+    top: 0px;
+}
+
+.social-icon {
+    min-width: 50px;
+    margin: 4px;
+}
+
 
 .starter-template {
     margin-top: 25px;
@@ -176,6 +214,7 @@ p {
 
     .starter-template .content h1 {
         margin-bottom: 20px;
+        margin-top: 20px;
     }
 
     .starter-template .links {
@@ -188,9 +227,33 @@ p {
         float: none;
         text-align: center;
     }
+
+    .no-label-list {
+        list-style-type: none;
+        padding-left: 0px;
+    }
 }
 
 @media (max-width: 767px) {
+
+    .site-header {
+        flex-wrap: wrap;
+    }
+
+    .site-icon {
+        margin-top: 10px;
+        margin-bottom: -10px;
+    }
+
+    .site-title {
+        width: 100%;
+        padding: 0px 45px;
+    }
+
+    .site-social-icons {
+        width: 80px;
+    }
+
     .starter-template .content h1 .smaller {
         font-size: 25px;
         display: block;
@@ -261,4 +324,29 @@ p {
 .dataframe tbody tr.active-row {
     font-weight: bold;
     color: #009879;
+}
+
+@media (max-width: 399px) {
+    body {
+        min-width: 100vw;
+        padding: 0px;
+    }
+
+    #modeIcon2 {
+        display: none;
+    }
+
+    .container {
+        width: 100vw;
+        min-width: 300px;
+        padding: 20px;
+    }
+
+    .content {
+        box-sizing: content-box;
+    }
+
+    .site-title {
+        padding: 0px;
+    }
 }

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -2,21 +2,28 @@
 
 {% block content %}
 
-<div style="margin: auto; float: right;">
-    <a href="https://github.com/timskovjacobsen/steelprofiles_api">
-        <img style="width: 42px; float: left;" src="/static/img/github-icon.svg" alt="GitHub Icon" id="modeIcon2">
-    </a>
-    <button class="toggleDarkMode" onclick="darkMode()">
-        <img style="float: right; filter: invert(1);" src="/static/img/button-dark-mode.svg" alt="" id="modeIcon" />
-    </button>
+<div class="site-social-icons">
+    <div class="social-icon">
+        <a href="https://github.com/timskovjacobsen/steelprofiles_api">
+            <img style="width: 47px;" src="/static/img/github-icon.svg" alt="GitHub Icon" id="modeIcon2">
+        </a>
+    </div>
+    <div class="social-icon">
+        <button class="toggleDarkMode" onclick="darkMode()">
+            <img style="filter: invert(1);" src="/static/img/button-dark-mode.svg" alt="" id="modeIcon" />
+        </button>
+    </div>
+</div> 
+
+<div class="site-header">
+    <div class="site-icon">
+        <img src="/static/img/favicon.png" style="max-width: 48px;" alt="">
+    </div>
+ 
+    <div class="site-title">
+        <h1 class="font-semi-bold">Steel&nbsp;Profiles REST&nbsp;API</h1>
+    </div>
 </div>
-
-<img src="/static/img/favicon.png" style="float: left; max-width: 48px; margin-right: 20px;" alt="">
-
-<h1 class="font-semi-bold">Steel Profiles REST API</h1>
-
-
-<div style="clear:both;"></div>
 <br>
 <p class="intro">
     A simple REST API for requesting data for common European steel profiles.<br>
@@ -26,7 +33,7 @@
 </p>
 
 <h2>Endpoints</h2>
-<ul>
+<ul class="no-label-list">
     <li>
         <strong><code>GET
                 /api/{profile_type}</code></strong><br>
@@ -47,7 +54,7 @@
 
 <p>The metric units used for the steel dimensions in this API are:</p>
 <div>
-    <ul>
+    <ul class="no-label-list">
         <li><code>h: mm</code></li>
         <li><code>b: mm</code></li>
         <li><code>tw: mm</code></li>


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

## Description

Hello & happy hacktoberfest! This PR contains suggestions for improving the index page layout for mobile users. With these changes, the site should now be responsive down to 320px viewport widths. Please let me know if you have any suggested changes to layout, I'm happy to change it further to your taste! I have included screenshots below of the appearance at various viewport widths.

It does *not* address making the subpages mobile-friendly, just the index. I can add a commit to address those other pages but wanted to check that the index page design decisions went in the right direction first.

Partially fixes #13 

## Screenshots

**320px Viewport Width**
<img width="26%" alt="Screen Shot 2021-10-30 at 3 48 15 PM" src="https://user-images.githubusercontent.com/84106309/139556800-952ab003-3bf9-43c7-ab5f-942cd4eab0b9.png">

**400px Viewport Width**
<img width="33%" alt="Screen Shot 2021-10-30 at 3 48 39 PM" src="https://user-images.githubusercontent.com/84106309/139556801-0f73be0b-2ded-42c0-b50f-00b1f273c5b4.png">

**766px Viewport Width**
<img width="63%" alt="Screen Shot 2021-10-30 at 3 48 59 PM" src="https://user-images.githubusercontent.com/84106309/139556896-8d70d810-e176-48b6-b8d2-6d371b74ab74.png">

**900-ish Viewport Width**
<img width="76%" alt="Screen Shot 2021-10-30 at 3 49 10 PM" src="https://user-images.githubusercontent.com/84106309/139556805-66cd8143-7fad-4fab-a1f9-7783555c6da7.png">

**991px+ Viewport Width**
<img width="97%" alt="Screen Shot 2021-10-30 at 4 16 33 PM" src="https://user-images.githubusercontent.com/84106309/139557283-1c0da8cb-cf75-41e2-a01c-f83ed261d698.png">

**1199px+ Viewport Width**
<img width="100%" alt="Screen Shot 2021-10-30 at 4 16 21 PM" src="https://user-images.githubusercontent.com/84106309/139557324-c7ed757d-f5f8-4bc6-8946-c21aabeae5d7.png">


